### PR TITLE
Correct `project` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,7 +529,12 @@ where
     }
     /// Project this vector onto another
     fn project(self, other: Self) -> Self {
-        other.unit().mul(self.dot(other) * self.mag())
+        let mag = other.mag();
+        if mag < Self::Scalar::EPSILON {
+            Self::new(Self::Scalar::ZERO, Self::Scalar::ZERO)
+        } else {
+            other.unit().mul(self.dot(other) / mag)
+        }
     }
 }
 


### PR DESCRIPTION
The `project` method in `FloatingVector2` was multiplying by the length of the first vector, but it should have been dividing by the length of the second vector. This change fixes the formula, which now also requires checking to avoid division by 0. If projecting onto a vector shorter than epsilon, a zero vector is returned.