### PR TITLE
make no_std compatible

### DIFF
--- a/src/group.rs
+++ b/src/group.rs
@@ -1,4 +1,4 @@
-use std::iter::{once, Chain, Once};
+use core::iter::{once, Chain, Once};
 
 /// An iterator over two items
 pub type Chain2<T> = Chain<Once<T>, Once<T>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "simd", feature(doc_cfg))]
 
 /*!
@@ -277,7 +278,7 @@ macro_rules! float_mod {
 float_mod!(f32);
 float_mod!(f64);
 
-use std::ops::Neg;
+use core::ops::Neg;
 
 pub use Circle as _;
 pub use Rectangle as _;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Neg, Sub};
+use core::ops::{Add, Div, Mul, Neg, Sub};
 
 /// Trait for math with scalar numbers
 pub trait Scalar:
@@ -162,5 +162,5 @@ macro_rules! floating_scalar_impl {
     };
 }
 
-floating_scalar_impl!(f32, std::f32::consts::PI, std::f32::EPSILON);
-floating_scalar_impl!(f64, std::f64::consts::PI, std::f64::EPSILON);
+floating_scalar_impl!(f32, core::f32::consts::PI, core::f32::EPSILON);
+floating_scalar_impl!(f64, core::f64::consts::PI, core::f64::EPSILON);

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Mul};
+use core::ops::{Add, Mul};
 
 use crate::{FloatingScalar, Pair, Scalar, Trio, Vector2};
 


### PR DESCRIPTION
This change makes the library `no_std` compatible, allowing it to be used in situations where `std` isn't available, such as embedded platforms or, importantly, on some game consoles.
See: https://lurklurk.org/effective-rust/no-std.html